### PR TITLE
enable CORS

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const app = express();
+const cors = require('cors');
 // Load model plugins
 require('./models/register-plugins');
 const ensureKey = require('../lib/middleware/ensure-key');
@@ -10,6 +11,7 @@ const checkConnection = require('./middleware/check-connection');
 
 app.use(morgan('dev', { skip: () => process.env.NODE_ENV === 'test' }));
 
+app.use(cors());
 app.use(express.json());
 app.use(checkConnection());
 

--- a/lib/routes/auth.js
+++ b/lib/routes/auth.js
@@ -47,8 +47,6 @@ router
   })
 
   .post('/signin', ({ body }, res, next) => {
-    console.log(body);
-    
     const { email, password } = body;
 
     checkCredentialsExist(email, password)

--- a/lib/routes/auth.js
+++ b/lib/routes/auth.js
@@ -47,6 +47,8 @@ router
   })
 
   .post('/signin', ({ body }, res, next) => {
+    console.log(body);
+    
     const { email, password } = body;
 
     checkCredentialsExist(email, password)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1430,6 +1430,15 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
+    },
     "create-error-class": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
@@ -5108,8 +5117,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "bcryptjs": "^2.4.3",
     "chalk": "^2.4.2",
+    "cors": "^2.8.5",
     "dotenv": "^8.1.0",
     "express": "^4.17.1",
     "mongoose": "^5.7.1",


### PR DESCRIPTION
Enable CORS (Cross Origin Resource Sharing) in all routes so that front ends can access the API from domains other than heroku.com and from http and https. 
This update required a change to package.json - please run `npm i` when you pull into your workspace
Tests have 100% coverage