### PR TITLE
Random samples on GET routes

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const app = express();
+const cors = require('cors');
 // Load model plugins
 require('./models/register-plugins');
 const ensureKey = require('../lib/middleware/ensure-key');
@@ -10,6 +11,7 @@ const checkConnection = require('./middleware/check-connection');
 
 app.use(morgan('dev', { skip: () => process.env.NODE_ENV === 'test' }));
 
+app.use(cors());
 app.use(express.json());
 app.use(checkConnection());
 

--- a/lib/middleware/query-parser.js
+++ b/lib/middleware/query-parser.js
@@ -14,21 +14,25 @@ module.exports = function queryParser() {
 
         if(keyOperator.length === 1) {
           let format = value.replace('%20', ' ').replace('+', ' ');
+          if(key === 'width' || key === 'height' || key === 'solutionLength' || key === 'connectivity' || key === 'averagePathLength') {
+            format = Number(format);
+          }
           acc[key] = format;
           return acc;
         }
 
         key = keyOperator[0];
         let operator = keyOperator[1];
+
         if(acc[key]) {
           const values = acc[key];
-          values[`$${operator}`] = value;
+          values[`$${operator}`] = Number(value);
           acc[key] = values;
           return acc;
         }
 
         const values = {};
-        values[`$${operator}`] = value;
+        values[`$${operator}`] = Number(value);
         acc[key] = values;
         return acc;
 

--- a/lib/middleware/query-parser.js
+++ b/lib/middleware/query-parser.js
@@ -6,36 +6,26 @@ module.exports = function queryParser() {
 
     if(url) {
       const searchParams = url.split('&');
+
       const query = searchParams.reduce((acc, val) => {
-        const entry = val.split('=');
-        let key = entry[0];
-        const value = entry[1];
-        const keyOperator = key.split('_');
+        let [param, value] = val.split('=');
+        const paramArr = param.split('_');
 
-        if(keyOperator.length === 1) {
-          let format = value.replace('%20', ' ').replace('+', ' ');
-          if(key === 'width' || key === 'height' || key === 'solutionLength' || key === 'connectivity' || key === 'averagePathLength') {
-            format = Number(format);
+        if(paramArr.length === 1) {
+          value = value.replace('%20', ' ').replace('+', ' ');
+          if(param === 'width' || param === 'height' || param === 'solutionLength' || param === 'connectivity' || param === 'averagePathLength') {
+            value = Number(value);
           }
-          acc[key] = format;
+          acc[param] = value;
           return acc;
         }
 
-        key = keyOperator[0];
-        let operator = keyOperator[1];
-
-        if(acc[key]) {
-          const values = acc[key];
-          values[`$${operator}`] = Number(value);
-          acc[key] = values;
-          return acc;
-        }
-
-        const values = {};
+        let [key, operator] = paramArr;
+        
+        const values = (acc[key]) ? acc[key] : {};
         values[`$${operator}`] = Number(value);
         acc[key] = values;
         return acc;
-
       }, {});
 
       const formattedQuery = Object.keys(query).reduce((acc, key) => {

--- a/lib/routes/auth.js
+++ b/lib/routes/auth.js
@@ -47,8 +47,6 @@ router
   })
 
   .post('/signin', ({ body }, res, next) => {
-    console.log(body);
-    
     const { email, password } = body;
 
     checkCredentialsExist(email, password)

--- a/lib/routes/auth.js
+++ b/lib/routes/auth.js
@@ -47,6 +47,8 @@ router
   })
 
   .post('/signin', ({ body }, res, next) => {
+    console.log(body);
+    
     const { email, password } = body;
 
     checkCredentialsExist(email, password)

--- a/lib/routes/maze-routes.js
+++ b/lib/routes/maze-routes.js
@@ -23,9 +23,20 @@ router
       delete query.number;
     }
 
-    Maze.find(query)
-      .limit(number)
-      .lean()
+    const convertToNumber = (obj, key) => {
+      if(obj[key]) obj[key] = Number(obj[key]);
+    };
+    convertToNumber(query, 'dimensions.width');
+    convertToNumber(query, 'dimensions.height');
+    if(query.solutionLength) convertToNumber(query.solutionLength, '$lt');
+    if(query.solutionLength) convertToNumber(query.solutionLength, '$gt');
+    if(query.connectivity) convertToNumber(query.connectivity, '$lt');
+    if(query.connectivity) convertToNumber(query.connectivity, '$gt');
+    
+    Maze.aggregate([
+      { $match: query },
+      { $sample: { size: number } }
+    ])
       .then(mazes => res.json(mazes))
       .catch(next);
 

--- a/lib/routes/maze-routes.js
+++ b/lib/routes/maze-routes.js
@@ -23,16 +23,6 @@ router
       delete query.number;
     }
 
-    const convertToNumber = (obj, key) => {
-      if(obj[key]) obj[key] = Number(obj[key]);
-    };
-    convertToNumber(query, 'dimensions.width');
-    convertToNumber(query, 'dimensions.height');
-    if(query.solutionLength) convertToNumber(query.solutionLength, '$lt');
-    if(query.solutionLength) convertToNumber(query.solutionLength, '$gt');
-    if(query.connectivity) convertToNumber(query.connectivity, '$lt');
-    if(query.connectivity) convertToNumber(query.connectivity, '$gt');
-    
     Maze.aggregate([
       { $match: query },
       { $sample: { size: number } }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1430,6 +1430,15 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
+    },
     "create-error-class": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
@@ -5108,8 +5117,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4700,6 +4700,12 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
+    "memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "optional": true
+    },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -4810,6 +4816,8 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.3.2.tgz",
       "integrity": "sha512-fqJt3iywelk4yKu/lfwQg163Bjpo5zDKhXiohycvon4iQHbrfflSAz9AIlRE6496Pm/dQKQK5bMigdVo2s6gBg==",
+      "dev": true,
+      "optional": true,
       "requires": {
         "bson": "^1.1.1",
         "require_optional": "^1.0.1",
@@ -4867,13 +4875,13 @@
       }
     },
     "mongoose": {
-      "version": "5.7.4",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.7.4.tgz",
-      "integrity": "sha512-IgqQS5HIaZ8tG2cib6QllfIw2Wc/A0QVOsdKLsSqRolqJFWOjI0se3vsKXLNkbEcuJ1xziW3e/jPhBs65678Hg==",
+      "version": "5.7.9",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.7.9.tgz",
+      "integrity": "sha512-wXYY4+IEvplbEEeOxLVOHBGosBDNn/DYgwKzBFgsamCTvRQZHbdw88m9xUH8Srza+jdKND73/4XbQLynPseRAQ==",
       "requires": {
         "bson": "~1.1.1",
         "kareem": "2.3.1",
-        "mongodb": "3.3.2",
+        "mongodb": "3.3.3",
         "mongoose-legacy-pluralize": "1.0.2",
         "mpath": "0.6.0",
         "mquery": "3.2.2",
@@ -4884,6 +4892,17 @@
         "sliced": "1.0.1"
       },
       "dependencies": {
+        "mongodb": {
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.3.3.tgz",
+          "integrity": "sha512-MdRnoOjstmnrKJsK8PY0PjP6fyF/SBS4R8coxmhsfEU7tQ46/J6j+aSHF2n4c2/H8B+Hc/Klbfp8vggZfI0mmA==",
+          "requires": {
+            "bson": "^1.1.1",
+            "require_optional": "^1.0.1",
+            "safe-buffer": "^5.1.2",
+            "saslprep": "^1.0.0"
+          }
+        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -6024,6 +6043,15 @@
         }
       }
     },
+    "saslprep": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+      "optional": true,
+      "requires": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -6332,6 +6360,15 @@
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
+    },
+    "sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
+      "optional": true,
+      "requires": {
+        "memory-pager": "^1.0.2"
+      }
     },
     "spdx-correct": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "bcryptjs": "^2.4.3",
     "chalk": "^2.4.2",
+    "cors": "^2.8.5",
     "dotenv": "^8.1.0",
     "express": "^4.17.1",
     "mongoose": "^5.7.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "cors": "^2.8.5",
     "dotenv": "^8.1.0",
     "express": "^4.17.1",
-    "mongoose": "^5.7.1",
+    "mongoose": "^5.7.9",
     "morgan": "^1.9.1"
   },
   "devDependencies": {


### PR DESCRIPTION
All GET requests now return a random sampling of mazes. The default number of returned mazes remains as 10. All query parameters from the URL are honored by the sampling.
The database .find() method has been replaced by a call to .aggregate(). Inside the aggregation, $match is used to find the subset of mazes that meet the query params; $sample is used to randomly select mazes from the subset. 
This enables users to make repeated GET requests and obtain different mazes each time